### PR TITLE
Add license configuration to .gemspec file

### DIFF
--- a/aws4.gemspec
+++ b/aws4.gemspec
@@ -4,6 +4,7 @@ Gem::Specification.new do |s|
   s.name         = 'aws4'
   s.version      = AWS4::VERSION
   s.summary      = "A ruby gem for AWS Signature version 4"
+  s.license      = "MIT"
   s.description  = "The approach is HTTP library agnostic, so you must supply method, uri, headers, and body"
   s.authors      = ["Brandon Keene"]
   s.email        = ["bkeene@gmail.com"]


### PR DESCRIPTION
Allows license detection for gems like [Papers](https://github.com/newrelic/papers)